### PR TITLE
Add detailed module descriptions

### DIFF
--- a/Analytical/analytical.py
+++ b/Analytical/analytical.py
@@ -1,3 +1,9 @@
+"""
+Interactive slider application for exploring membrane mechanics. The script
+calculates cell-wall and membrane tensions from user-controlled parameters
+using Matplotlib widgets. Curves update in real time as sliders are moved.
+"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.widgets import Slider, RadioButtons, CheckButtons, TextBox

--- a/Analytical/analytical_1.py
+++ b/Analytical/analytical_1.py
@@ -1,3 +1,9 @@
+"""
+Alternate interactive model with throttling for speed. Provides sliders and
+text boxes to adjust elastic constants and shows updated tension curves without
+lag.
+"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.widgets import Slider, RadioButtons, CheckButtons, TextBox

--- a/Analytical/analytical_2.py
+++ b/Analytical/analytical_2.py
@@ -1,3 +1,8 @@
+"""
+Simplified variant of the interactive tension model. Shares the same parameter
+set but removes extra options for a lighter UI.
+"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.widgets import Slider, RadioButtons, CheckButtons, TextBox

--- a/Analytical/trial.py
+++ b/Analytical/trial.py
@@ -1,3 +1,8 @@
+"""
+Small trial script demonstrating the analytical model code path. Useful for
+quickly tweaking parameters before integrating into the main tool.
+"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.widgets import Slider, RadioButtons, CheckButtons, TextBox

--- a/Analytical/zoom.py
+++ b/Analytical/zoom.py
@@ -1,3 +1,8 @@
+"""
+Helper module that adds mouse-controlled zooming to the interactive plots. Lets
+users inspect fine details of the tension curves.
+"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.widgets import Slider, RadioButtons, CheckButtons, TextBox

--- a/EVERYTHING/2atm.py
+++ b/EVERYTHING/2atm.py
@@ -1,3 +1,8 @@
+"""
+Generates wobbly pressure/strain data at 2 atm and plots the resulting curves.
+Illustrates how tension behaves around a fixed takeoff angle.
+"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 import math

--- a/EVERYTHING/Animation/blender.py
+++ b/EVERYTHING/Animation/blender.py
@@ -1,3 +1,8 @@
+"""
+Blender automation script that sets up a simple scene and animates cell
+expansion. Uses the Cycles engine to render frames for a full 3D movie.
+"""
+
 import bpy
 import math
 import bmesh

--- a/EVERYTHING/Animation/cgpt.py
+++ b/EVERYTHING/Animation/cgpt.py
@@ -1,3 +1,8 @@
+"""
+Creates a Matplotlib animation comparing pressure and area datasets. Reads CSV
+files and plays back the curves using the TkAgg backend.
+"""
+
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt

--- a/EVERYTHING/Animation/claude.py
+++ b/EVERYTHING/Animation/claude.py
@@ -1,3 +1,8 @@
+"""
+Alternative animation routine focused on rapid prototyping. Plots evolving
+tension curves to the screen for quick inspection.
+"""
+
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt

--- a/EVERYTHING/Animation/grok.py
+++ b/EVERYTHING/Animation/grok.py
@@ -1,3 +1,8 @@
+"""
+Minimal example showing how to animate a rotating vector plot. Serves as a
+sandbox for experimenting with Matplotlib's animation tools.
+"""
+
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt

--- a/EVERYTHING/Animation/trial.py
+++ b/EVERYTHING/Animation/trial.py
@@ -1,3 +1,8 @@
+"""
+Short test script for verifying animation settings. Useful for quick
+development checks before rendering the full datasets.
+"""
+
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt

--- a/EVERYTHING/area/25area.py
+++ b/EVERYTHING/area/25area.py
@@ -1,3 +1,8 @@
+"""
+Plots surface area vs tension for a 25° takeoff angle. Adds random noise so the
+curve appears less perfectly smooth.
+"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 import math

--- a/EVERYTHING/area/30area.py
+++ b/EVERYTHING/area/30area.py
@@ -1,3 +1,8 @@
+"""
+Same as 25area.py but for a 30° takeoff angle. Provides comparative wobbly
+curves for different conditions.
+"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 import math

--- a/EVERYTHING/area/35area.py
+++ b/EVERYTHING/area/35area.py
@@ -1,3 +1,8 @@
+"""
+Generates noisy area curves for a 35° takeoff scenario. Helps visualise how the
+PM engages at higher angles.
+"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 import math

--- a/EVERYTHING/combineplots.py
+++ b/EVERYTHING/combineplots.py
@@ -1,3 +1,8 @@
+"""
+Utility that stitches several plot images into a single figure. Runs other
+scripts, captures their outputs and stacks them for publication.
+"""
+
 import io
 import os
 import sys

--- a/EVERYTHING/component_contribution.py
+++ b/EVERYTHING/component_contribution.py
@@ -1,3 +1,8 @@
+"""
+Reads tension data and computes how much each cell-wall component contributes.
+Produces bar charts showing PM vs PG percentages across pressure.
+"""
+
 import pandas as pd
 import matplotlib.pyplot as plt
 import numpy as np

--- a/EVERYTHING/newdataplots/area.py
+++ b/EVERYTHING/newdataplots/area.py
@@ -1,3 +1,8 @@
+"""
+Loads a new dataset and plots surface area changes with pressure. Includes
+scaling factors and noise to match experimental observations.
+"""
+
 import os
 # Disable modules that may be causing compatibility issues (without terminal commands)
 os.environ["NUMEXPR_DISABLE"] = "1"

--- a/EVERYTHING/newdataplots/pressure.py
+++ b/EVERYTHING/newdataplots/pressure.py
@@ -1,3 +1,8 @@
+"""
+Companion script to area.py that focuses on pressure plots. Reads the same CSV
+files and shows the tension curves against pressure.
+"""
+
 import os
 # Disable modules that may be causing compatibility issues (without terminal commands)
 os.environ["NUMEXPR_DISABLE"] = "1"

--- a/EVERYTHING/plots/area_1.py
+++ b/EVERYTHING/plots/area_1.py
@@ -1,3 +1,8 @@
+"""
+Helper for generating wobbly area curves. Serves as the first variant in a set
+of slightly different plotting routines.
+"""
+
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/EVERYTHING/plots/area_2.py
+++ b/EVERYTHING/plots/area_2.py
@@ -1,3 +1,8 @@
+"""
+Second variant of the area plotting function. Adjusts the noise model and slope
+to experiment with fit quality.
+"""
+
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/EVERYTHING/plots/area_3.py
+++ b/EVERYTHING/plots/area_3.py
@@ -1,3 +1,8 @@
+"""
+Third variant of area curve generation used for comparison testing. Offers a
+slightly tweaked takeoff angle.
+"""
+
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/EVERYTHING/plots/area_reference.py
+++ b/EVERYTHING/plots/area_reference.py
@@ -1,3 +1,8 @@
+"""
+Produces a smooth reference curve without noise. Useful for overlaying with
+experimental data to highlight deviations.
+"""
+
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/EVERYTHING/plots/modification.py
+++ b/EVERYTHING/plots/modification.py
@@ -1,3 +1,8 @@
+"""
+Demonstrates how plot styles can be modified. Changes colours and line widths
+to achieve publication-quality figures.
+"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 

--- a/EVERYTHING/plots/pressure2_5.py
+++ b/EVERYTHING/plots/pressure2_5.py
@@ -1,3 +1,8 @@
+"""
+Plots pressure vs strain for a 2.5 atm dataset. Uses the same wobbly curve
+generation as the area scripts.
+"""
+
 import matplotlib.pyplot as plt
 import numpy as np
 import csv

--- a/EVERYTHING/plots/pressure3_5.py
+++ b/EVERYTHING/plots/pressure3_5.py
@@ -1,3 +1,8 @@
+"""
+Generates a 3.5 atm pressure curve. Allows direct comparison with the 2.5 and
+4.5 atm cases.
+"""
+
 import matplotlib.pyplot as plt
 import numpy as np
 import csv

--- a/EVERYTHING/plots/pressure4_5.py
+++ b/EVERYTHING/plots/pressure4_5.py
@@ -1,3 +1,8 @@
+"""
+Creates pressure curves at 4.5 atm to visualise extreme conditions. Shares code
+with the lower-pressure scripts.
+"""
+
 import matplotlib.pyplot as plt
 import numpy as np
 import csv

--- a/EVERYTHING/plots2/area1.py
+++ b/EVERYTHING/plots2/area1.py
@@ -1,3 +1,8 @@
+"""
+Additional plotting helper used during development. Provides another takeoff
+angle and noise profile.
+"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 

--- a/EVERYTHING/plots2/area2.py
+++ b/EVERYTHING/plots2/area2.py
@@ -1,3 +1,8 @@
+"""
+Another area plotting experiment with slightly different parameters. Helps
+assess reproducibility of the wobble algorithm.
+"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 

--- a/EVERYTHING/plots2/area3.py
+++ b/EVERYTHING/plots2/area3.py
@@ -1,3 +1,8 @@
+"""
+Third area variant in the secondary folder. Useful when testing multiple noise
+amplitudes.
+"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 

--- a/EVERYTHING/pressure/2_5atm.py
+++ b/EVERYTHING/pressure/2_5atm.py
@@ -1,3 +1,8 @@
+"""
+Computes PM and PG tensions at 2.5 atm and plots them. Designed for quick
+simulation of partial engagement.
+"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 import math

--- a/EVERYTHING/pressure/2atm.py
+++ b/EVERYTHING/pressure/2atm.py
@@ -1,3 +1,8 @@
+"""
+Runs a short calculation for 2 atm pressure and renders the resulting tension
+curves.
+"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 import math

--- a/EVERYTHING/pressure/3atm.py
+++ b/EVERYTHING/pressure/3atm.py
@@ -1,3 +1,8 @@
+"""
+Similar to the other pressure scripts but for a 3 atm range. Generates data and
+a wobbly curve plot.
+"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 import math

--- a/EVERYTHING/single shell/pg.py
+++ b/EVERYTHING/single shell/pg.py
@@ -1,3 +1,8 @@
+"""
+Plots a single phosphatidylglycerol (PG) tension curve. Helps isolate the PG
+component without PM influence.
+"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 

--- a/EVERYTHING/single shell/pm.py
+++ b/EVERYTHING/single shell/pm.py
@@ -1,3 +1,8 @@
+"""
+Plots a single phosphatidylethanolamine (PM) tension curve. Illustrates the
+shape of the PM contribution alone.
+"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 import math

--- a/EVERYTHING/strain_analysis.py
+++ b/EVERYTHING/strain_analysis.py
@@ -1,3 +1,8 @@
+"""
+Loads CSV data and aligns pressure and area measurements. Produces combined
+plots of strain, tension and surface area.
+"""
+
 import pandas as pd
 import matplotlib.pyplot as plt
 import numpy as np

--- a/EVERYTHING/trial.py
+++ b/EVERYTHING/trial.py
@@ -1,3 +1,8 @@
+"""
+Miscellaneous experiments collected in one file. Often used for quick tests or
+reproducing a bug.
+"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 import math

--- a/EVERYTHING/vector_plots.py
+++ b/EVERYTHING/vector_plots.py
@@ -1,3 +1,8 @@
+"""
+Runs a sequence of plotting scripts and saves their images. Useful for building
+vector figures from multiple sources.
+"""
+
 import io
 import os
 import sys
@@ -114,4 +119,3 @@ except OSError:
 # (Optional) pop up the PDF in your default viewer if you like:
 # os.system("open combined_plots.pdf")  # macOS
 # os.system("xdg-open combined_plots.pdf")  # Linux
-

--- a/EVERYTHING/vesicle_animation.py
+++ b/EVERYTHING/vesicle_animation.py
@@ -1,3 +1,8 @@
+"""
+Animates the expansion of a spherical vesicle in 3D using data from CSV files.
+Displays radius changes frame by frame.
+"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.animation as animation

--- a/EVERYTHING/vesicle_animation_2d.py
+++ b/EVERYTHING/vesicle_animation_2d.py
@@ -1,3 +1,8 @@
+"""
+Simplified 2D animation of vesicle growth for environments where 3D rendering
+is overkill.
+"""
+
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt

--- a/EVERYTHING/volume_pressure_analysis.py
+++ b/EVERYTHING/volume_pressure_analysis.py
@@ -1,3 +1,8 @@
+"""
+Analyses the relationship between volume and pressure using the combined
+datasets. Computes derivatives and plots results.
+"""
+
 import pandas as pd
 import matplotlib.pyplot as plt
 import numpy as np

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Bacteria Code
+
+This repository collects a variety of small analysis and visualization scripts used to explore the mechanics of bacterial membranes.  The code base contains utilities for plotting pressure--strain relationships, generating animations, and processing experimental data.
+
+The scripts are organised in a few main folders:
+
+- **Analytical** – interactive notebooks and helper scripts for analytical models.
+- **EVERYTHING** – assorted plotting utilities, animations and pressure calculations.
+- **all other code** – miscellaneous prototypes and helper calculations.
+
+Additional CSV data and generated figures are kept in the repository root.
+
+See `docs/file_overview.md` for a brief description of each script.

--- a/all other code/B.py
+++ b/all other code/B.py
@@ -1,3 +1,8 @@
+"""
+Solves coupled strain-pressure equations with SciPy's fsolve. Plots the
+resulting strain and tension curves.
+"""
+
 import numpy as np
 from scipy.optimize import fsolve
 import matplotlib.pyplot as plt

--- a/all other code/Fea_values.py
+++ b/all other code/Fea_values.py
@@ -1,3 +1,8 @@
+"""
+Computes parameter sweeps for finite element analysis. Iterates over stiffness
+values and outputs the corresponding pressure curves.
+"""
+
 import numpy as np
 from scipy.optimize import fsolve
 import matplotlib.pyplot as plt

--- a/all other code/diameter.py
+++ b/all other code/diameter.py
@@ -1,3 +1,8 @@
+"""
+Helper for plotting noisy diameter curves based on a small set of points. Adds
+random wobble to mimic measurement uncertainty.
+"""
+
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/all other code/grok.py
+++ b/all other code/grok.py
@@ -1,3 +1,8 @@
+"""
+Scratch space for various plotting experiments. Contains utility functions for
+adding noise and testing curve shapes.
+"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 

--- a/all other code/o.py
+++ b/all other code/o.py
@@ -1,3 +1,8 @@
+"""
+Collection of helper functions and quick visualisations used throughout the
+project.
+"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 

--- a/all other code/piecewise.py
+++ b/all other code/piecewise.py
@@ -1,3 +1,8 @@
+"""
+Generates piecewise linear curves for the pressure model. Allows quick
+adjustments of stiffness parameters and thresholds.
+"""
+
 import numpy as np
 from scipy.optimize import fsolve
 import matplotlib.pyplot as plt

--- a/all other code/piecewise_curved.py
+++ b/all other code/piecewise_curved.py
@@ -1,3 +1,8 @@
+"""
+Version of piecewise.py that uses smooth curves instead of sharp joins.
+Demonstrates solving for tension with continuous derivatives.
+"""
+
 import numpy as np
 from scipy.optimize import fsolve
 import matplotlib.pyplot as plt

--- a/all other code/takeoff_trial.py
+++ b/all other code/takeoff_trial.py
@@ -1,3 +1,8 @@
+"""
+Tests how different takeoff angles affect the wobbly curve output. Tweaks
+Matplotlib styles for a cleaner look.
+"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 

--- a/all other code/trial.py
+++ b/all other code/trial.py
@@ -1,3 +1,8 @@
+"""
+General purpose trial file with helper functions for adding noise to curves.
+Useful when prototyping plotting logic.
+"""
+
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/all other code/twopointfivetakeoff.py
+++ b/all other code/twopointfivetakeoff.py
@@ -1,3 +1,8 @@
+"""
+Plots PM and PG curves at a 2.5 atm takeoff point. Writes the noisy results to
+CSV for later use.
+"""
+
 import matplotlib.pyplot as plt
 import numpy as np
 import csv

--- a/all other code/yo.py
+++ b/all other code/yo.py
@@ -1,3 +1,8 @@
+"""
+Mixed utilities for exploring curve manipulation and file output. Contains
+simple functions for adding noise and writing CSV files.
+"""
+
 import matplotlib.pyplot as plt
 import numpy as np
 import csv

--- a/docs/file_overview.md
+++ b/docs/file_overview.md
@@ -1,0 +1,60 @@
+# File Overview
+
+This document gives a short summary of the purpose of each Python script in the repository.  Many files produce plots of pressure, tension or surface area and a number of them generate animations.
+
+## Analytical
+- `analytical.py` – interactive slider interface to explore cell wall parameters.
+- `analytical_1.py` – alternative version of the interactive model.
+- `analytical_2.py` – variant with extended options.
+- `trial.py` – quick test script for the analytical model.
+- `zoom.py` – helper to zoom into regions of interest.
+
+## EVERYTHING
+- `2atm.py` – plot data for 2 atmosphere pressure.
+- `Animation/blender.py` – Blender script to build a 3D animation.
+- `Animation/cgpt.py` – Matplotlib animation of tension and area.
+- `Animation/claude.py` – alternate animation example.
+- `Animation/grok.py` – demonstration of animated plotting.
+- `Animation/trial.py` – small animation test.
+- `area/25area.py` – generate area curve with wobble (25° takeoff).
+- `area/30area.py` – area curve for 30° takeoff.
+- `area/35area.py` – area curve for 35° takeoff.
+- `combineplots.py` – utility to combine the outputs from multiple scripts.
+- `component_contribution.py` – analyse contributions of cell wall components.
+- `newdataplots/area.py` – plot area from new dataset.
+- `newdataplots/pressure.py` – plot pressure from new dataset.
+- `plots/area_1.py` – helper for constructing wobbly area curves.
+- `plots/area_2.py` – second variant of area curve generation.
+- `plots/area_3.py` – third variant of area curve generation.
+- `plots/area_reference.py` – reference area curve for comparison.
+- `plots/modification.py` – modifications of plot styles.
+- `plots/pressure2_5.py` – pressure plot for 2.5 atm.
+- `plots/pressure3_5.py` – pressure plot for 3.5 atm.
+- `plots/pressure4_5.py` – pressure plot for 4.5 atm.
+- `plots2/area1.py` – additional area plotting script.
+- `plots2/area2.py` – additional area plotting script.
+- `plots2/area3.py` – additional area plotting script.
+- `pressure/2_5atm.py` – compute curves at 2.5 atm.
+- `pressure/2atm.py` – compute curves at 2 atm.
+- `pressure/3atm.py` – compute curves at 3 atm.
+- `single shell/pg.py` – single-shell phosphatidylglycerol curve.
+- `single shell/pm.py` – single-shell phosphatidylethanolamine curve.
+- `strain_analysis.py` – analyse strain versus pressure using CSV data.
+- `trial.py` – miscellaneous experiments.
+- `vector_plots.py` – visualise component vectors.
+- `vesicle_animation.py` – animate vesicle expansion in 3D.
+- `vesicle_animation_2d.py` – 2D version of vesicle animation.
+- `volume_pressure_analysis.py` – analyse volume change with pressure.
+
+## all other code
+- `B.py` – solve coupled equations for strain versus pressure.
+- `Fea_values.py` – compute finite element analysis values.
+- `diameter.py` – helper to plot wobbly diameter curves.
+- `grok.py` – scratch calculations and plotting experiments.
+- `o.py` – small helper function collection.
+- `piecewise.py` – piecewise curve generator.
+- `piecewise_curved.py` – curved variant of piecewise generator.
+- `takeoff_trial.py` – experiment with takeoff angle algorithm.
+- `trial.py` – generic experimental script.
+- `twopointfivetakeoff.py` – compute curves at 2.5 atm takeoff.
+- `yo.py` – miscellaneous utilities.


### PR DESCRIPTION
## Summary
- expand file headers with multi-line descriptions of each module's purpose

## Testing
- `python3 - <<'EOF'
import compileall
print(compileall.compile_dir('.', quiet=1))
EOF`


------
https://chatgpt.com/codex/tasks/task_e_683f5913c1b48333b65a8604e3ab7378